### PR TITLE
Better name and description in metadata

### DIFF
--- a/userscript_compile.cjs
+++ b/userscript_compile.cjs
@@ -11,12 +11,12 @@ let styles_to_compile = [
 ]
 
 let compile_userscript = parts => `// ==UserScript==
-// @name         Svelte Userscript
+// @name         Cohost Mutant Standard Emoji Picker
 // @namespace    https://svelte.dev/
 // @version      0.2.4
 // @updateURL    https://lxhom.github.io/mutant-html/mutant-compiled.user.js
 // @downloadURL  https://lxhom.github.io/mutant-html/mutant-compiled.user.js
-// @description  try to take over the world!
+// @description  Use Mutant Standard emoji in chosts!
 // @author       cohost.org/lexi
 // @match        https://cohost.org/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=cohost.org


### PR DESCRIPTION
Gives the userscript a proper name/description in greasemonkey or your userscript manager of choice instead of just "Svelte Userscript" with the description "try to take over the world!"